### PR TITLE
Add PhotonVision simulation support

### DIFF
--- a/src/main/java/Team4450/Robot24/Assignments
+++ b/src/main/java/Team4450/Robot24/Assignments
@@ -88,7 +88,7 @@ POV_?                   Auto rotate to the POV direction.
 ?                       Reset simulated distance traveled.
 ?                       Switch Shuffleboard tab.
 ?                       Switch Camera.
-B                       Toggle drive wheel brake mode.
+B                       Toggle Drive To Note command
 X                       
 A                       Toggle April Tag Tracking mode.
 
@@ -96,17 +96,24 @@ A                       Toggle April Tag Tracking mode.
 Utility GamePad - Left Joystick
 Button Name				Function
 -----------------------------------------------------------------------------------
+Y_AXIS                  Pivot shooter assembly
 
 
 Utility GamePad - Right Joystick
 Button Name				Function
 -----------------------------------------------------------------------------------
+Y_AXIS                  Move climber/elevator
 
 
 Utility GamePad - Buttons
 Button Name				Function
 -----------------------------------------------------------------------------------
 B                       Toggles Intake Motors.
+Y                       Intake then immediately shoot
+LEFT_TRIGGER            Reverse shooter sushi-rollers (hold)
+RIGHT_TRIGGER           Feed shooter sushi-rollers (hold)
+LEFT_BUMPER             Intake note
+RIGHT_BUMPER            Shoot Note
 
 
 Dashboard Indicators/Controls

--- a/src/main/java/Team4450/Robot24/Constants.java
+++ b/src/main/java/Team4450/Robot24/Constants.java
@@ -67,10 +67,10 @@ public final class Constants
         new Translation3d(0, 0, 0),
         new Rotation3d(0, 0, 0)
     );
-
-    public static String        CAMERA_POSE_ESTIMATOR = "4450-LL";
+    // the names of the cameras in the PhotonVision software
+    public static String        CAMERA_POSE_ESTIMATOR = "";
     public static String        CAMERA_FRONT = "4450-LL";
-    public static String        CAMERA_BACK = "4450-LL";
+    public static String        CAMERA_BACK = "back";
 
     public static final int     REV_PDB = 0;
 	

--- a/src/main/java/Team4450/Robot24/RobotContainer.java
+++ b/src/main/java/Team4450/Robot24/RobotContainer.java
@@ -21,6 +21,7 @@ import Team4450.Robot24.subsystems.DriveBase;
 import Team4450.Robot24.subsystems.PhotonVision;
 import Team4450.Robot24.subsystems.Intake;
 import Team4450.Robot24.subsystems.ShuffleBoard;
+import Team4450.Robot24.subsystems.PhotonVision.PipelineType;
 import Team4450.Lib.MonitorPDP;
 import Team4450.Lib.NavX;
 import Team4450.Lib.Util;
@@ -164,9 +165,9 @@ public class RobotContainer
 
 		shuffleBoard = new ShuffleBoard();
 		driveBase = new DriveBase();
-		pvPoseCamera = new PhotonVision(CAMERA_POSE_ESTIMATOR, CAMERA_POSE_TRANSFORM);
-		pvBackCamera = new PhotonVision(CAMERA_BACK);
-		pvFrontCamera = new PhotonVision(CAMERA_FRONT);
+		pvPoseCamera = new PhotonVision(CAMERA_POSE_ESTIMATOR, PipelineType.APRILTAG_TRACKING, CAMERA_POSE_TRANSFORM);
+		pvBackCamera = new PhotonVision(CAMERA_BACK, PipelineType.APRILTAG_TRACKING);
+		pvFrontCamera = new PhotonVision(CAMERA_FRONT, PipelineType.OBJECT_TRACKING);
 		intake = new Intake();
 
 		// Create any persistent commands.
@@ -174,9 +175,10 @@ public class RobotContainer
 		// Set any subsystem Default commands.
 
 		// This sets up the photonVision subsystem to constantly update the robotDrive odometry
-	    // with AprilTags (if it sees them).
-
+	    // with AprilTags (if it sees them). (As well as vision simulator)
     	pvPoseCamera.setDefaultCommand(new UpdateVisionPose(pvPoseCamera, driveBase));
+		pvFrontCamera.setDefaultCommand(new UpdateVisionPose(pvFrontCamera, driveBase));
+		pvBackCamera.setDefaultCommand(new UpdateVisionPose(pvBackCamera, driveBase));
 
 		// Set the default drive command. This command will be scheduled automatically to run
 		// every teleop period and so use the gamepad joy sticks to drive the robot. 
@@ -319,7 +321,7 @@ public class RobotContainer
 
 		// toggle Note tracking.
 	    new Trigger(() -> driverController.getBButton())
-    	    .toggleOnTrue(new DriveToNote(driveBase, pvPoseCamera));
+    	    .toggleOnTrue(new DriveToNote(driveBase, pvFrontCamera));
 
 		// Advance DS tab display.
 		//new Trigger(() -> driverPad.getPOVAngle(90))

--- a/src/main/java/Team4450/Robot24/commands/UpdateVisionPose.java
+++ b/src/main/java/Team4450/Robot24/commands/UpdateVisionPose.java
@@ -8,6 +8,7 @@ import Team4450.Lib.Util;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.wpilibj2.command.Command;
+import Team4450.Robot24.Robot;
 import Team4450.Robot24.subsystems.DriveBase;
 import Team4450.Robot24.subsystems.PhotonVision;
 
@@ -17,6 +18,10 @@ import Team4450.Robot24.subsystems.PhotonVision;
  * object with timestamped vision poses. The pose estimator then
  * merges these predicted poses with what the actual odometry on
  * the robot is doing and produces a smoothed "true" pose.
+ * 
+ * Also, this class updates the visionSim object with the robots
+ * pose so that the visionSim can accurately calculate targets
+ * in the simulator.
  */
 public class UpdateVisionPose extends Command {
     PhotonVision    cameraSubsystem;
@@ -43,6 +48,11 @@ public class UpdateVisionPose extends Command {
 
     @Override
     public void execute() {
+        if (Robot.isSimulation()) {
+            cameraSubsystem.updateSimulationPose(robotDrive.getPose());
+            return; // if simulator don't try updating pose estimator because the
+                    // odometry is already "perfect"
+        }
         Optional<EstimatedRobotPose> estimatedPoseOptional = cameraSubsystem.getEstimatedPose();
 
         // update pose estimator pose with current epoch timestamp and the pose from the camera

--- a/src/main/java/Team4450/Robot24/subsystems/PhotonVision.java
+++ b/src/main/java/Team4450/Robot24/subsystems/PhotonVision.java
@@ -9,6 +9,10 @@ import org.photonvision.PhotonCamera;
 import org.photonvision.PhotonPoseEstimator;
 import org.photonvision.PhotonPoseEstimator.PoseStrategy;
 import org.photonvision.common.hardware.VisionLEDMode;
+import org.photonvision.estimation.TargetModel;
+import org.photonvision.simulation.PhotonCameraSim;
+import org.photonvision.simulation.VisionSystemSim;
+import org.photonvision.simulation.VisionTargetSim;
 import org.photonvision.targeting.PhotonPipelineResult;
 import org.photonvision.targeting.PhotonTrackedTarget;
 
@@ -38,6 +42,8 @@ public class PhotonVision extends SubsystemBase
     private PhotonPipelineResult    latestResult;
     private VisionLEDMode           ledMode = VisionLEDMode.kOff;
 
+    private VisionSystemSim         visionSim;
+
     private Field2d                 field = new Field2d();
 
     private final AprilTagFields    fields = AprilTagFields.k2024Crescendo;
@@ -45,13 +51,16 @@ public class PhotonVision extends SubsystemBase
     private PhotonPoseEstimator     poseEstimator;
 
     private Transform3d             robotToCam;
+    private PipelineType            pipelineType;
+
+    public static enum PipelineType {APRILTAG_TRACKING, OBJECT_TRACKING};
 
     /**
      * Create an instance of PhotonVision class for a camera.
      * @param cameraName The name of the camera.
      */
-    public PhotonVision(String cameraName) {
-        this(cameraName, new Transform3d());
+    public PhotonVision(String cameraName, PipelineType pipelineType) {
+        this(cameraName, pipelineType, new Transform3d());
     }
 
     /**
@@ -59,11 +68,21 @@ public class PhotonVision extends SubsystemBase
      * @param cameraName The name of the camera.
      * @param robotToCam A Transform3d locating the camera on the robot chassis.
      */
-	public PhotonVision(String cameraName, Transform3d robotToCam)
+	public PhotonVision(String cameraName, PipelineType pipelineType, Transform3d robotToCam)
 	{
         camera = new PhotonCamera(cameraName);
         this.robotToCam = robotToCam;
+        selectPipeline(pipelineType);
         fieldLayout = fields.loadAprilTagLayoutField();
+
+        // adds a simulated camera to the vision sim: "real" camera will
+        // act just like normal on real robot and in sim!
+        visionSim = new VisionSystemSim(cameraName);
+        PhotonCameraSim cameraSim = new PhotonCameraSim(camera);
+        cameraSim.enableDrawWireframe(true);
+        visionSim.addCamera(cameraSim, robotToCam);
+
+        setUpSimTargets();
 
         // setup the AprilTag pose etimator.
         poseEstimator = new PhotonPoseEstimator(
@@ -74,11 +93,76 @@ public class PhotonVision extends SubsystemBase
         );
 
         setLedMode(ledMode);
-
 		Util.consoleLog("PhotonVision (%s) created!", cameraName);
-
         SmartDashboard.putData(field);
 	}
+
+    /**
+     * sets up simulation targets for simulated vision system
+     */
+    private void setUpSimTargets() {
+        visionSim.clearAprilTags();
+        visionSim.clearVisionTargets();
+        switch (pipelineType) {
+            case APRILTAG_TRACKING:
+                visionSim.addAprilTags(fieldLayout);
+                break;
+            case OBJECT_TRACKING:
+                // approximate coordinates on on-field notes
+                addNoteSimTarget(2.9, 7, 0);
+                addNoteSimTarget(2.9, 5.6, 1);
+                addNoteSimTarget(2.9, 4.1, 2);
+                addNoteSimTarget(8.3, 7.5, 3);
+                addNoteSimTarget(8.3, 5.8, 4);
+                addNoteSimTarget(8.3, 4.1, 5);
+                addNoteSimTarget(8.3, 2.4, 6);
+                addNoteSimTarget(8.3, 0.75, 7);
+                addNoteSimTarget(13.65, 7, 8);
+                addNoteSimTarget(13.65, 5.6, 9);
+                addNoteSimTarget(13.65, 4.1, 10);
+                break;
+        }
+    }
+
+    /**
+     * adds a sim target of a Note
+     * @param x field coordinate X
+     * @param y field coordinate Y
+     * @param id zero-based index of note
+     */
+    private void addNoteSimTarget(double x, double y, int id) {
+        TargetModel noteModel = new TargetModel(0.3556, 0.3556, 0.0508);
+        VisionTargetSim target = new VisionTargetSim(
+            new Pose3d(new Pose2d(x, y, new Rotation2d())),
+            noteModel
+        );
+        visionSim.addVisionTargets("note"+Integer.toString(id), target);
+
+    }
+
+
+    @Override
+    public void simulationPeriodic() {
+        if (pipelineType == PipelineType.OBJECT_TRACKING) {
+            // this stuff allows us to drag around the note in simgui
+            // to change position of the note
+            for (int noteID=0;noteID<11;noteID++) {
+                String name = "note"+Integer.toString(noteID);
+                Pose2d fieldPose = visionSim.getDebugField().getObject(name).getPose();
+                if (fieldPose.getX() == 0 && fieldPose.getY() == 0) continue;
+                visionSim.getVisionTargets(name).forEach((target)->target.setPose(new Pose3d(fieldPose)));
+            }
+        }
+    }
+
+    /**
+     * updates the simulated pose of the robot for use in the PhotonVision
+     * simulated vision code
+     * @param pose the pose of robot (ONLY BASED OFF OF ODOMETRY: NOT ANY POSE ESTIMATORS)
+     */
+    public void updateSimulationPose(Pose2d pose) {
+        visionSim.update(pose);
+    }
 
     /**
      * Get the lastest target results object returned by the camera.
@@ -160,7 +244,7 @@ public class PhotonVision extends SubsystemBase
      * Returns the yaw angle of the best target in the latest camera results
      * list. Must call hasTargets() before calling this function.
      * @return Best target yaw value from straight ahead or zero. -yaw means
-     * target is left of robot center.
+     * target is left of robot center. (degrees)
      */
     public double getYaw()
     {
@@ -221,6 +305,17 @@ public class PhotonVision extends SubsystemBase
         Util.consoleLog("%d", index);
 
         camera.setPipelineIndex(index);
+    }
+
+    /**
+     * Sets the pipline of the photonvision camera given an enum type.
+     * This also allows us to use simulation pretty well!
+     * @param type the type of pipeline
+     */
+    public void selectPipeline(PipelineType type) {
+        this.pipelineType = type;
+        setUpSimTargets();
+        selectPipeline(type.ordinal());
     }
 
     /**

--- a/src/main/java/Team4450/Robot24/subsystems/PhotonVision.java
+++ b/src/main/java/Team4450/Robot24/subsystems/PhotonVision.java
@@ -72,7 +72,6 @@ public class PhotonVision extends SubsystemBase
 	{
         camera = new PhotonCamera(cameraName);
         this.robotToCam = robotToCam;
-        selectPipeline(pipelineType);
         fieldLayout = fields.loadAprilTagLayoutField();
 
         // adds a simulated camera to the vision sim: "real" camera will
@@ -82,6 +81,7 @@ public class PhotonVision extends SubsystemBase
         cameraSim.enableDrawWireframe(true);
         visionSim.addCamera(cameraSim, robotToCam);
 
+        selectPipeline(pipelineType);
         setUpSimTargets();
 
         // setup the AprilTag pose etimator.

--- a/src/main/java/Team4450/Robot24/subsystems/PhotonVision.java
+++ b/src/main/java/Team4450/Robot24/subsystems/PhotonVision.java
@@ -171,8 +171,10 @@ public class PhotonVision extends SubsystemBase
     }
 
     /**
-     * returns pitch value of the best target in latest camera results
-     * @return best target pitch value
+     * Returns the pitch angle of the best target in the latest camera results
+     * list. Must call hasTargets() before calling this function.
+     * @return Best target pitch value from straight ahead or zero. -pitch means
+     * target is below camera center. (degrees)
      */
     public double getPitch()
     {


### PR DESCRIPTION
This change allows us to simulate AprilTag tracking and Note tracking in simgui. A Field2d widget is created for each camera with its targets. In addition, I have made it so we can drag the notes around on the field and have the robot dynamically respond. I also updated assignments file.